### PR TITLE
Fixes bug (assumed imports are done with double quote)

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -36,8 +36,8 @@ const config: HardhatUserConfig = {
       transform: (line: string) => {
         if (line.match(/^\s*import /i)) {
           getRemappings().forEach(([find, replace]) => {
-            if (line.match('"' + find)) {
-              line = line.replace('"' + find, '"' + replace);
+            if (line.match(find)) {
+              line = line.replace(find, replace);
             }
           });
         }


### PR DESCRIPTION
Not sure why the replace was done assuming imports were done with double quotes.
Here's an example that resulted in a bug for me: https://github.com/Uniswap/v2-periphery/blob/master/contracts/libraries/UniswapV2Library.sol#L3